### PR TITLE
Fix concurrent map access issue

### DIFF
--- a/lrserver.go
+++ b/lrserver.go
@@ -21,6 +21,10 @@ Multiple servers can be instantiated, and each can support multiple connections.
 package lrserver
 
 const (
+
+	// DefaultName is the livereload Server's default name
 	DefaultName string = "LiveReload"
+
+	// DefaultPort is the livereload Server's default server port
 	DefaultPort uint16 = 35729
 )

--- a/lrserver_test.go
+++ b/lrserver_test.go
@@ -138,7 +138,7 @@ func Test(t *testing.T) {
 					}
 
 					_, _, err := conn.NextReader()
-					So(reflect.TypeOf(err).String(), ShouldEqual, "*websocket.closeError")
+					So(reflect.TypeOf(err).String(), ShouldEqual, "*websocket.CloseError")
 				})
 
 				// Send valid handshake


### PR DESCRIPTION
First off, thanks for the wonderful library, saves a ton of time in development!

I encountered a concurrent map access issue and this pull request fixes this issue:

```

2016/07/08 14:57:58 stderr: fatal error: concurrent map writes
2016/07/08 14:57:58 stderr: [LiveReload] websocket: close 1008 (policy violation): websocket: bad handshake
2016/07/08 14:57:58 stderr:
2016/07/08 14:57:58 stderr: goroutine 65305 [running]:
2016/07/08 14:57:58 stderr: runtime.throw(0xf63f80, 0x15)
2016/07/08 14:57:58 stderr: 	/usr/local/opt/go/libexec/src/runtime/panic.go:547 +0x90 fp=0xc827a39bd0 sp=0xc827a39bb8
2016/07/08 14:57:58 stderr: runtime.mapdelete(0xdd0c40, 0xc821f88810, 0xc827a39c90)
2016/07/08 14:57:58 stderr: 	/usr/local/opt/go/libexec/src/runtime/hashmap.go:559 +0x5a fp=0xc827a39c30 sp=0xc827a39bd0
2016/07/08 14:57:58 stderr: github.com/jaschaephraim/lrserver.(*conn).close(0xc8216abb00, 0x3f0, 0x1b50028, 0xc82000b610, 0x0, 0x0)
2016/07/08 14:57:58 stderr: 	/Users/anthony/go/src/github.com/jaschaephraim/lrserver/connection.go:140 +0x60a fp=0xc827a39e00 sp=0xc827a39c30
2016/07/08 14:57:58 stderr: github.com/jaschaephraim/lrserver.(*conn).badHandshake(0xc8216abb00)
2016/07/08 14:57:58 stderr: 	/Users/anthony/go/src/github.com/jaschaephraim/lrserver/connection.go:107 +0x42 fp=0xc827a39e38 sp=0xc827a39e00
2016/07/08 14:57:58 stderr: github.com/jaschaephraim/lrserver.(*conn).transmit(0xc8216abb00)
2016/07/08 14:57:58 stderr: 	/Users/anthony/go/src/github.com/jaschaephraim/lrserver/connection.go:84 +0x112 fp=0xc827a39fa8 sp=0xc827a39e38

```